### PR TITLE
Seed Infrahub with device data on GCP VM

### DIFF
--- a/docs/running-the-worker.md
+++ b/docs/running-the-worker.md
@@ -14,6 +14,8 @@ Step-by-step guide to start the Temporal worker and execute a network change wor
 
 ## Step 1: Deploy the Project to the VM
 
+> **Note:** If you want to run `NetworkChangeWorkflow` end-to-end, your worker **must** be able to reach the `172.20.20.x` Containerlab node IP addresses. Usually this means starting the worker on the GCP VM itself, or setting up Tailscale Subnet Routing to advertise the `172.20.20.0/24` network.
+
 ```bash
 # SSH into the VM
 gcloud compute ssh synapse-vm-01 --zone=us-central1-a

--- a/tests/integration/test_placeholder.py
+++ b/tests/integration/test_placeholder.py
@@ -49,7 +49,7 @@ def test_infrahub_device_config_retrieval():
         assert config is not None
 
         bgp_vars = config.to_bgp_template_vars()
-        assert bgp_vars.local_as > 0
+        assert bgp_vars.local_asn > 0
 
         iface_vars = config.to_interface_template_vars()
         assert len(iface_vars.interfaces) > 0


### PR DESCRIPTION
Resolves #49.
- Seeded the Infrahub database with schemas and device data on the GCP VM. 
- Updated `running-the-worker.md` instructions indicating how to correctly configure network routes to the Containerlab nodes for the worker to successfully connect. 
- Fixed an attribute mapping error from `local_as` to `local_asn` in `test_placeholder.py` so integration tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated worker deployment documentation to clarify network connectivity requirements and recommended configuration approaches.

* **Tests**
  * Updated integration tests to reflect field naming updates in BGP template configuration variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->