### PR TITLE
ci: add issue close guard workflow

### DIFF
--- a/.github/workflows/issue-close-guard.yml
+++ b/.github/workflows/issue-close-guard.yml
@@ -29,22 +29,27 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
-          # Search open PRs whose body references this issue with a closing keyword
+          # Search open PRs whose body references this issue
+          PATTERN="(?i)(closes|fixes|resolves)\\\\s+#${ISSUE_NUMBER}\\\\b"
+          JQ_EXPR="[.[] | select(.body | test(\"$PATTERN\"))] | length"
           OPEN_PRS=$(gh pr list \
             --repo "$REPO" \
             --state open \
             --json number,body,title \
-            --jq "[.[] | select(.body | test(\"(?i)(closes|fixes|resolves)\\\\s+#${ISSUE_NUMBER}\\\\b\"))] | length")
+            --jq "$JQ_EXPR")
 
           echo "open_prs=$OPEN_PRS" >> "$GITHUB_OUTPUT"
 
           if [ "$OPEN_PRS" -gt 0 ]; then
             echo "⚠️  Found $OPEN_PRS open PR(s) linked to issue #${ISSUE_NUMBER}."
+            PATTERN="(?i)(closes|fixes|resolves)\\\\s+#${ISSUE_NUMBER}\\\\b"
+            FILTER="[.[] | select(.body | test(\"$PATTERN\"))]"
+            FORMAT="map(\"- #\\(.number) — \\(.title)\") | join(\"\\n\")"
             PR_LIST=$(gh pr list \
               --repo "$REPO" \
               --state open \
               --json number,title,body \
-              --jq "[.[] | select(.body | test(\"(?i)(closes|fixes|resolves)\\\\s+#${ISSUE_NUMBER}\\\\b\"))] | map(\"- #\\(.number) — \\(.title)\") | join(\"\\n\")")
+              --jq "$FILTER | $FORMAT")
             echo "pr_list<<EOF" >> "$GITHUB_OUTPUT"
             echo "$PR_LIST" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
@@ -69,7 +74,9 @@ jobs:
 
           ${PR_LIST}
 
-          Per our [issue management guidelines](dev/guidelines/issue-management.md), issues should only be closed by merging the associated PR into \`develop\` — never manually.
+          Per our [issue management guidelines](dev/guidelines/issue-management.md),
+          issues should only be closed by merging the associated PR
+          into \`develop\` — never manually.
 
           > _This check is enforced by the Issue Close Guard workflow._
           COMMENT

--- a/.github/workflows/issue-close-guard.yml
+++ b/.github/workflows/issue-close-guard.yml
@@ -1,0 +1,78 @@
+# Issue close guard — prevent premature issue closure
+#
+# If an issue is closed while it still has an open (unmerged) PR linked via
+# "Closes #N" / "Fixes #N" / "Resolves #N", this workflow will reopen the
+# issue and leave an explanatory comment.
+#
+# Rationale: Issues should only transition to "Done" when the associated PR
+# merges into develop.  See dev/guidelines/issue-management.md.
+
+name: Issue Close Guard
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  guard:
+    name: Check for unmerged linked PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Look for open PRs that close this issue
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Search open PRs whose body references this issue with a closing keyword
+          OPEN_PRS=$(gh pr list \
+            --repo "$REPO" \
+            --state open \
+            --json number,body,title \
+            --jq "[.[] | select(.body | test(\"(?i)(closes|fixes|resolves)\\\\s+#${ISSUE_NUMBER}\\\\b\"))] | length")
+
+          echo "open_prs=$OPEN_PRS" >> "$GITHUB_OUTPUT"
+
+          if [ "$OPEN_PRS" -gt 0 ]; then
+            echo "⚠️  Found $OPEN_PRS open PR(s) linked to issue #${ISSUE_NUMBER}."
+            PR_LIST=$(gh pr list \
+              --repo "$REPO" \
+              --state open \
+              --json number,title,body \
+              --jq "[.[] | select(.body | test(\"(?i)(closes|fixes|resolves)\\\\s+#${ISSUE_NUMBER}\\\\b\"))] | map(\"- #\\(.number) — \\(.title)\") | join(\"\\n\")")
+            echo "pr_list<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$PR_LIST" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          else
+            echo "✅  No open PRs linked — issue can stay closed."
+          fi
+
+      - name: Reopen issue and comment
+        if: steps.check.outputs.open_prs != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          PR_LIST: ${{ steps.check.outputs.pr_list }}
+        run: |
+          gh issue reopen "$ISSUE_NUMBER" --repo "$REPO"
+
+          COMMENT_BODY=$(cat <<COMMENT
+          🔄 **Issue reopened automatically.**
+
+          This issue was closed while it still has unmerged PR(s) linked to it:
+
+          ${PR_LIST}
+
+          Per our [issue management guidelines](dev/guidelines/issue-management.md), issues should only be closed by merging the associated PR into \`develop\` — never manually.
+
+          > _This check is enforced by the Issue Close Guard workflow._
+          COMMENT
+          )
+
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$COMMENT_BODY"

--- a/dev/guidelines/issue-management.md
+++ b/dev/guidelines/issue-management.md
@@ -89,6 +89,16 @@ As you commit work that completes a sub-task, edit the issue body and tick the c
 
 This gives anyone viewing the issue a real-time progress picture without needing to read commit history.
 
+## Automated Guardrails
+
+The **Issue Close Guard** workflow (`.github/workflows/issue-close-guard.yml`) enforces the rule that issues must only be closed via PR merge:
+
+- Triggers whenever an issue is closed.
+- Checks for any open (unmerged) PRs that reference the issue with `Closes #N` / `Fixes #N` / `Resolves #N`.
+- If an unmerged PR is found, the workflow **reopens the issue** and leaves a comment explaining why.
+
+This prevents accidental or premature manual closures.
+
 ## Agent Rules
 
 > **AI agents MUST follow these rules when working on issues.**

--- a/dev/knowledge/cicd-architecture.md
+++ b/dev/knowledge/cicd-architecture.md
@@ -587,6 +587,8 @@ All templates share a component dropdown: Backend, Workers, CI/CD, Docker/Infras
 | `ci.yml` | Push to develop | Post-merge validation + integration tests |
 | `deploy.yml` | Manual dispatch | Deploy to dev/staging/prod |
 | `build-artifacts.yml` | Push tag `v*` | Docker build + package build |
+| `bug-triage.yml` | Issue opened | Auto-label bug reports with `triage` |
+| `issue-close-guard.yml` | Issue closed | Reopen if unmerged PR still linked |
 
 Shared environment:
 
@@ -672,7 +674,26 @@ Triggered on tags matching `v*`:
 - **build-docker** -- Uses `docker/setup-buildx-action`, builds from `development/Dockerfile`
 - **build-package** -- `uv build --package <name>` for each workspace package, uploads `dist/` as artifact
 
-### 9.7 Pinned Action Versions
+### 9.7 Bug Triage (Issue Opened)
+
+Triggers when a new issue is opened. If the issue was created from the Bug Report template, the workflow:
+
+- Adds the `triage` label to flag it for maintainer review.
+- Posts an automated welcome comment acknowledging the report.
+
+### 9.8 Issue Close Guard (Issue Closed)
+
+Triggers whenever an issue is closed. Prevents premature manual closures by checking whether the issue still has open (unmerged) PRs linked via `Closes #N` / `Fixes #N` / `Resolves #N`.
+
+**Behavior:**
+
+- Searches all open PRs for closing keyword references to the closed issue.
+- If an unmerged PR is found, **reopens the issue** and leaves a comment listing the linked PR(s) with a pointer to the issue management guidelines.
+- If no open PRs reference the issue, the closure stands.
+
+This enforces the policy documented in `dev/guidelines/issue-management.md`: issues must only be closed by merging their associated PR into `develop`.
+
+### 9.9 Pinned Action Versions
 
 | Action | Version |
 |--------|---------|


### PR DESCRIPTION
Closes #49

## Summary
- Adds `.github/workflows/issue-close-guard.yml` — a workflow that triggers on `issues.closed` events and checks for open (unmerged) PRs linked via `Closes/Fixes/Resolves #N`. If found, the issue is automatically reopened with a comment explaining why.
- Updates `dev/guidelines/issue-management.md` with an **Automated Guardrails** section documenting the new workflow.

## Context
Issue #49 was manually closed while PR #70 was still open and unmerged against `develop`. This workflow prevents that from happening again by enforcing the policy that issues should only be closed by merging their associated PR.

## Test plan
- [ ] Verify workflow YAML is valid (CI will check)
- [ ] Manually close an issue that has an open linked PR and confirm the workflow reopens it with a comment
- [ ] Close an issue with no linked PRs and confirm it stays closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Implemented automated guardrails for issue management to prevent premature closure when pull requests are still in progress.
* Issues will automatically reopen if closed while linked pull requests remain unmerged, with a notification explaining the issue management policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->