### PR TITLE
ci: add release workflow with changelog enforcement

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,7 @@ name: PR Validation
 on:
   pull_request:
     branches: [main, develop]
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   PYTHON_VERSION: "3.11"
@@ -37,6 +38,56 @@ jobs:
             echo "  Resolves #123"
             echo ""
             echo "This ensures the PR appears in the 'Linked pull requests' column on the project board."
+            exit 1
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Changelog fragment check — enforce towncrier fragment in user-facing PRs
+  # ---------------------------------------------------------------------------
+  changelog-check:
+    name: Changelog Check
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: >-
+      !startsWith(github.head_ref, 'dependabot/') &&
+      !(github.event.pull_request.base.ref == 'main' &&
+      (github.head_ref == 'develop' ||
+      startsWith(github.head_ref, 'release/'))) &&
+      !contains(github.event.pull_request.labels.*.name,
+      'skip-changelog')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for changelog fragment
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "Checking for changelog fragments in this PR..."
+          echo ""
+
+          FRAGMENTS=$(git diff --name-only --diff-filter=AM \
+            "$BASE_SHA"..."$HEAD_SHA" -- 'changelog/*.md' \
+            | grep -v '.gitkeep' || true)
+
+          if [ -n "$FRAGMENTS" ]; then
+            echo "Found changelog fragment(s):"
+            echo "$FRAGMENTS"
+            echo ""
+            echo "Changelog check passed."
+          else
+            echo "No changelog fragment found in this PR."
+            echo ""
+            echo "Please add a changelog fragment file:"
+            echo "  echo \"Description\" > changelog/<issue-number>.<type>.md"
+            echo ""
+            echo "Types: added, changed, deprecated, removed, fixed, security"
+            echo ""
+            echo "If this change does not need a changelog entry (CI-only,"
+            echo "docs-only, test-only, or internal refactoring), ask a"
+            echo "maintainer to add the 'skip-changelog' label to this PR."
             exit 1
           fi
 
@@ -298,7 +349,14 @@ jobs:
   pr-summary:
     name: PR Summary
     runs-on: ubuntu-latest
-    needs: [issue-link-check, code-quality, security-scanning, secrets-detection, unit-tests, uv-lock-check]
+    needs:
+      - issue-link-check
+      - changelog-check
+      - code-quality
+      - security-scanning
+      - secrets-detection
+      - unit-tests
+      - uv-lock-check
     if: always()
     steps:
       - name: Check job results
@@ -308,6 +366,7 @@ jobs:
           echo "| Job | Status |"
           echo "|-----|--------|"
           echo "| Issue Link Check | ${{ needs.issue-link-check.result }} |"
+          echo "| Changelog Check | ${{ needs.changelog-check.result }} |"
           echo "| Code Quality | ${{ needs.code-quality.result }} |"
           echo "| Security Scanning | ${{ needs.security-scanning.result }} |"
           echo "| Secrets Detection | ${{ needs.secrets-detection.result }} |"
@@ -316,6 +375,7 @@ jobs:
           echo ""
 
           if [[ "${{ needs.issue-link-check.result }}" == "failure" ]] || \
+             [[ "${{ needs.changelog-check.result }}" == "failure" ]] || \
              [[ "${{ needs.code-quality.result }}" == "failure" ]] || \
              [[ "${{ needs.secrets-detection.result }}" == "failure" ]] || \
              [[ "${{ needs.unit-tests.result }}" == "failure" ]] || \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,253 @@
+# Release — build changelog, tag, and create GitHub Release
+#
+# Trigger manually via Actions → Release → Run workflow.
+# Specify the version (e.g., "0.2.0").
+#
+# Prerequisites (one-time admin setup):
+#   1. In Settings → Rules → Rulesets → "Protect main" →
+#      Bypass list → add "Repository admin" role (Always).
+#   2. Create a Fine-grained PAT with Contents: Read/Write,
+#      scoped to this repo only. Store as RELEASE_PAT secret.
+#
+# What this workflow does:
+#   1. Validates all closed issues have changelog fragments
+#   2. Compiles fragments into CHANGELOG.md via towncrier
+#   3. Commits updated CHANGELOG.md to main
+#   4. Creates and pushes git tag (v<version>)
+#   5. Creates GitHub Release with generated notes
+#   6. Tag push triggers build-artifacts.yml automatically
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g., 0.2.0)"
+        required: true
+        type: string
+      skip-validation:
+        description: >-
+          Skip completeness validation (emergency releases only)
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  issues: read
+
+env:
+  PYTHON_VERSION: "3.11"
+  UV_VERSION: "latest"
+
+jobs:
+  release:
+    name: Release v${{ inputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        run: |
+          VERSION="${{ inputs.version }}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Invalid version format: $VERSION"
+            echo "Expected: MAJOR.MINOR.PATCH (e.g., 0.2.0)"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      # ── Layer 3: Completeness validation ──────────────────
+      - name: Validate changelog completeness
+        if: ${{ !inputs.skip-validation }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          echo "══════════════════════════════════════════════"
+          echo "  Changelog Completeness Validation"
+          echo "══════════════════════════════════════════════"
+          echo ""
+
+          # Find the last version tag
+          LAST_TAG=$(git tag -l 'v*' --sort=-version:refname \
+            | head -n1)
+
+          if [ -z "$LAST_TAG" ]; then
+            echo "No previous tag found. Using initial commit."
+            SINCE_DATE=$(git log --reverse --format='%aI' \
+              | head -n1)
+          else
+            echo "Last tag: $LAST_TAG"
+            SINCE_DATE=$(git log -1 --format='%aI' "$LAST_TAG")
+          fi
+
+          echo "Checking issues closed since: $SINCE_DATE"
+          echo ""
+
+          # Get closed issues (completed, not "not planned"),
+          # excluding issues with exclusion labels.
+          ISSUES=$(gh issue list \
+            --state closed \
+            --limit 500 \
+            --search "closed:>=${SINCE_DATE} reason:completed" \
+            --json number,title,labels \
+            --jq '
+              [.[] | select(
+                ([.labels[].name] | any(
+                  . == "duplicate" or . == "wontfix" or
+                  . == "question" or . == "invalid" or
+                  . == "skip-changelog"
+                )) | not
+              )]
+            ')
+
+          ISSUE_COUNT=$(echo "$ISSUES" | jq 'length')
+          echo "Found $ISSUE_COUNT closed issues to check."
+          echo ""
+
+          MISSING=""
+          MISSING_COUNT=0
+
+          for row in $(echo "$ISSUES" \
+            | jq -r '.[] | @base64'); do
+            _jq() {
+              echo "$row" | base64 --decode | jq -r "$1"
+            }
+            NUM=$(_jq '.number')
+            TITLE=$(_jq '.title')
+
+            FOUND=$(ls changelog/${NUM}.*.md 2>/dev/null \
+              || true)
+            if [ -z "$FOUND" ]; then
+              MISSING="${MISSING}  - #${NUM}: ${TITLE}\n"
+              MISSING_COUNT=$((MISSING_COUNT + 1))
+            else
+              echo "  [ok] #${NUM}: ${TITLE}"
+            fi
+          done
+
+          echo ""
+
+          # Orphan fragment check (warnings only)
+          echo "── Orphan fragment check ──"
+          ORPHANS=""
+          for frag in changelog/*.md; do
+            [ "$frag" = "changelog/.gitkeep" ] && continue
+            BASENAME=$(basename "$frag")
+            ISSUE_NUM=$(echo "$BASENAME" \
+              | grep -oE '^[0-9]+' || true)
+            if [ -n "$ISSUE_NUM" ]; then
+              IN_SET=$(echo "$ISSUES" \
+                | jq --arg n "$ISSUE_NUM" \
+                '[.[] | select(.number == ($n | tonumber))]
+                | length')
+              if [ "$IN_SET" = "0" ]; then
+                ORPHANS="${ORPHANS}  - ${BASENAME}"
+                ORPHANS="${ORPHANS} (issue #${ISSUE_NUM}"
+                ORPHANS="${ORPHANS} not in closed set)\n"
+              fi
+            fi
+          done
+
+          if [ -n "$ORPHANS" ]; then
+            echo "WARNING: Orphan fragments found:"
+            echo -e "$ORPHANS"
+          else
+            echo "  No orphan fragments found."
+          fi
+
+          echo ""
+
+          if [ "$MISSING_COUNT" -gt 0 ]; then
+            echo "══════════════════════════════════════════════"
+            echo "  FAILED: $MISSING_COUNT issue(s) missing"
+            echo "  changelog fragments:"
+            echo "══════════════════════════════════════════════"
+            echo -e "$MISSING"
+            echo ""
+            echo "To fix:"
+            echo "  1. Add fragments:"
+            echo "     echo \"Desc\" > changelog/<N>.added.md"
+            echo "  2. Or add 'skip-changelog' label to issues"
+            echo "     that don't need fragments"
+            echo "  3. Re-run this release workflow"
+            exit 1
+          fi
+
+          echo "Completeness validation passed."
+
+      # ── Generate release notes (draft) ────────────────────
+      - name: Generate release notes
+        id: notes
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          echo "Generating release notes for v${VERSION}..."
+
+          NOTES=$(uv run towncrier build \
+            --draft --version "$VERSION" 2>/dev/null)
+
+          echo "notes<<RELEASE_NOTES_EOF" >> "$GITHUB_OUTPUT"
+          echo "$NOTES" >> "$GITHUB_OUTPUT"
+          echo "RELEASE_NOTES_EOF" >> "$GITHUB_OUTPUT"
+
+          echo ""
+          echo "── Preview ──"
+          echo "$NOTES"
+
+      # ── Build changelog (removes fragments) ───────────────
+      - name: Build changelog
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          uv run towncrier build --version "$VERSION" --yes
+
+      # ── Commit and tag ────────────────────────────────────
+      - name: Commit changelog update
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add CHANGELOG.md changelog/
+          git commit -m "chore: release v${VERSION}
+
+          - Updated CHANGELOG.md via towncrier
+          - Removed compiled changelog fragments"
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          git push origin main --follow-tags
+
+      # ── Create GitHub Release ─────────────────────────────
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          NOTES: ${{ steps.notes.outputs.notes }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes "$NOTES" \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
           echo "Generating release notes for v${VERSION}..."
 
           NOTES=$(uv run towncrier build \
-            --draft --version "$VERSION" 2>/dev/null)
+            --draft --version "$VERSION")
 
           echo "notes<<RELEASE_NOTES_EOF" >> "$GITHUB_OUTPUT"
           echo "$NOTES" >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,8 @@ Uses Towncrier for changelog management. When making changes, add a fragment fil
 echo "Added BGP session validation workflow" > changelog/42.added.md
 ```
 
+CI enforces that every PR includes a changelog fragment. For PRs that don't need one (CI-only, docs-only, test-only, internal refactoring), add the `skip-changelog` label to skip the check.
+
 See `dev/guidelines/changelog.md` for details.
 
 ## Developer Documentation (dev/)

--- a/dev/guidelines/changelog.md
+++ b/dev/guidelines/changelog.md
@@ -46,3 +46,13 @@ uv run towncrier build --version 0.2.0
 - CI/CD updates
 - Documentation-only changes
 - Test-only changes
+
+## PR Enforcement
+
+CI automatically blocks PRs that don't include a changelog fragment. If your PR doesn't need one (CI-only, docs-only, test-only, or internal refactoring), ask a maintainer to add the `skip-changelog` label to skip the check.
+
+The check runs on every PR to `main` and `develop`. It is automatically skipped for:
+
+- Dependabot PRs
+- Release PRs (`develop` → `main` or `release/*` → `main`)
+- PRs with the `skip-changelog` label

--- a/dev/guidelines/git-workflow.md
+++ b/dev/guidelines/git-workflow.md
@@ -88,6 +88,41 @@ git submodule update --init --recursive
 git submodule update --remote library/schema-library
 ```
 
+## Release Process
+
+Releases are automated via the `Release` workflow (`.github/workflows/release.yml`).
+
+### How to create a release
+
+1. Ensure all features for the release are merged to `develop`
+2. Create and merge a PR from `develop` → `main`
+3. Go to **Actions → Release → Run workflow**
+4. Enter the version number (e.g., `0.2.0`)
+5. The workflow automatically:
+   - Validates all closed issues have changelog fragments
+   - Compiles fragments into `CHANGELOG.md` via Towncrier
+   - Commits the updated changelog to `main`
+   - Creates and pushes a git tag (`v0.2.0`)
+   - Creates a GitHub Release with the generated notes
+   - Triggers the build-artifacts workflow (Docker + Python packages)
+
+### Completeness validation
+
+Before publishing, the workflow checks that every issue closed since the last release tag has a corresponding `changelog/<issue>.*.md` fragment. Issues labeled `duplicate`, `wontfix`, `question`, `invalid`, or `skip-changelog` are excluded from this check.
+
+If issues are missing fragments, the workflow fails with a list of gaps. Fix by adding the missing fragments or labeling the issues with `skip-changelog`.
+
+### Emergency releases
+
+Use the `skip-validation` checkbox when triggering the workflow to bypass the completeness check. Use sparingly.
+
+### One-time admin setup
+
+The workflow commits directly to `main`. Two things are needed:
+
+1. In **Settings → Rules → Rulesets → "Protect main"** → Bypass list, add **"Repository admin"** role (set to "Always")
+2. Create a Fine-grained PAT (Contents: Read/Write, scoped to this repo) and store it as the **`RELEASE_PAT`** secret in Settings → Secrets → Actions
+
 ## Deployment (GitOps)
 
 Deployment is **fully automated** via GitHub Actions.


### PR DESCRIPTION
## Why

Closes #71

Release notes are currently built manually. There is no enforcement that PRs include changelog fragments, and no automated release workflow. This means releases can miss changes or closed issues.

## What Changed

**Layer 1 — PR-level enforcement** (`pr-validation.yml`):
- New `changelog-check` job blocks PRs without a `changelog/*.md` fragment
- Skipped for: dependabot PRs, release PRs (develop→main), PRs with `skip-changelog` label
- Added `labeled` trigger type so the workflow re-evaluates when labels are added
- Integrated into `pr-summary` aggregation gate

**Layer 2 — Release workflow** (`release.yml`, new file):
- Triggered via `workflow_dispatch` with version input (e.g., `0.2.0`)
- Compiles Towncrier fragments into `CHANGELOG.md`
- Commits changelog update to `main`, creates annotated tag, creates GitHub Release
- Tag push auto-triggers existing `build-artifacts.yml`

**Layer 3 — Completeness guard** (embedded in release workflow):
- Validates all issues closed since last `v*` tag have corresponding fragments
- Excludes issues labeled `duplicate`, `wontfix`, `question`, `invalid`, `skip-changelog`
- Warns about orphan fragments (informational)
- Skippable via `skip-validation` for emergency releases

**Documentation updates**:
- `dev/guidelines/changelog.md` — PR enforcement and `skip-changelog` label
- `dev/guidelines/git-workflow.md` — Release process section
- `AGENTS.md` — Changelog enforcement note
- `dev/knowledge/cicd-architecture.md` — Updated sections 9.3, 13, and 14

## How to Review

Key files in order:
1. `.github/workflows/pr-validation.yml` — changelog-check job (lines 44-92) and pr-summary updates
2. `.github/workflows/release.yml` — complete release workflow
3. Documentation files — for accuracy

## How to Test

1. **Layer 1**: Open a test PR without a changelog fragment → `Changelog Check` should fail
2. **Layer 2+3**: After merging, trigger Release workflow via Actions → Release → Run workflow

## Impact & Rollout

- [x] Backward compatible — existing PRs with fragments pass automatically
- [x] No new dependencies — uses existing Towncrier setup
- [x] One-time admin setup done — `RELEASE_PAT` secret and ruleset bypass configured

## Checklist

- [x] Linting passes (`yamllint` verified)
- [ ] Changelog fragment (this PR adds CI enforcement — use `skip-changelog`)
- [x] Documentation updated
- [x] Workflows tested via yamllint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual release workflow to build changelogs, tag, and publish releases.
  * Enforced changelog fragment requirement in PR validation; PR summary now shows changelog check results.
  * Expanded PR validation triggers to include reopened/synchronize/labeled events.

* **Documentation**
  * Updated release process with step-by-step guidance.
  * Added changelog enforcement rules, exceptions, and CI behavior.
  * Enhanced CI/CD docs to reflect new validation and release flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->