### PR TITLE
ci: add live-tests job and release-confidence gate for staging pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,6 +144,7 @@ jobs:
     name: Health Check
     runs-on: ubuntu-latest
     needs: [validate, deploy]
+    environment: ${{ needs.validate.outputs.deploy_env }}
     steps:
       - name: Set up SSH key
         run: |
@@ -171,3 +172,50 @@ jobs:
             # Infrahub responds
             curl -s -o /dev/null -w 'Infrahub:    HTTP %{http_code}\n' http://localhost:8000
           "
+
+  # ─────────────────────────────────────────────
+  # Live integration tests (staging only)
+  # ─────────────────────────────────────────────
+  live-tests:
+    name: Live Tests
+    runs-on: ubuntu-latest
+    needs: [validate, health-check]
+    if: needs.validate.outputs.deploy_env == 'staging'
+    environment: staging
+    steps:
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VM_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.VM_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Run live tests on staging VM
+        env:
+          REMOTE_HOST: ${{ secrets.VM_HOST }}
+          REMOTE_USER: ${{ secrets.VM_USER || 'anton' }}
+        run: |
+          SSH_KEY="$HOME/.ssh/deploy_key"
+          SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=no -o ConnectTimeout=15)
+
+          echo "Running live integration tests on staging VM..."
+
+          ssh "${SSH_OPTS[@]}" "${REMOTE_USER}@${REMOTE_HOST}" "
+            export PATH=\"\$HOME/.local/bin:\$PATH\"
+            cd ~/project-network-synapse-3
+            uv run pytest tests/integration/ -v -m live \
+              --timeout=120 \
+              --junitxml=live-test-results.xml
+          "
+
+          # Copy test results back
+          scp -i "$SSH_KEY" -o StrictHostKeyChecking=no \
+            "${REMOTE_USER}@${REMOTE_HOST}:~/project-network-synapse-3/live-test-results.xml" \
+            ./live-test-results.xml || true
+
+      - name: Upload live test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: live-test-results
+          path: live-test-results.xml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -196,10 +196,11 @@ jobs:
           REMOTE_USER: ${{ secrets.VM_USER || 'anton' }}
         run: |
           SSH_KEY="$HOME/.ssh/deploy_key"
-          SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=no -o ConnectTimeout=15)
+          SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=yes -o ConnectTimeout=15)
 
           echo "Running live integration tests on staging VM..."
 
+          set +e
           ssh "${SSH_OPTS[@]}" "${REMOTE_USER}@${REMOTE_HOST}" "
             export PATH=\"\$HOME/.local/bin:\$PATH\"
             cd ~/project-network-synapse-3
@@ -207,11 +208,15 @@ jobs:
               --timeout=120 \
               --junitxml=live-test-results.xml
           "
+          TEST_EXIT=$?
+          set -e
 
-          # Copy test results back
-          scp -i "$SSH_KEY" -o StrictHostKeyChecking=no \
+          # Always copy test results back, even on failure
+          scp -i "$SSH_KEY" -o StrictHostKeyChecking=yes \
             "${REMOTE_USER}@${REMOTE_HOST}:~/project-network-synapse-3/live-test-results.xml" \
             ./live-test-results.xml || true
+
+          exit "$TEST_EXIT"
 
       - name: Upload live test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -363,6 +363,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --workflow=deploy.yml \
             --branch=develop \
+            --event=push \
             --limit=1 \
             --json conclusion,status,createdAt \
             --jq '.[0]')

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -344,6 +344,55 @@ jobs:
             Please update documentation if these changes affect development workflows.
 
   # ---------------------------------------------------------------------------
+  # Staging confidence — verify last staging deploy succeeded (main PRs only)
+  # ---------------------------------------------------------------------------
+  staging-confidence:
+    name: Staging Confidence
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'main'
+    permissions:
+      actions: read
+    steps:
+      - name: Check last staging deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Checking most recent Deploy workflow run on develop branch..."
+
+          RESULT=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow=deploy.yml \
+            --branch=develop \
+            --limit=1 \
+            --json conclusion,status,createdAt \
+            --jq '.[0]')
+
+          if [ -z "$RESULT" ] || [ "$RESULT" = "null" ]; then
+            echo "No staging deployment found on develop branch."
+            echo "A successful staging deployment is required before merging to main."
+            exit 1
+          fi
+
+          STATUS=$(echo "$RESULT" | jq -r '.status')
+          CONCLUSION=$(echo "$RESULT" | jq -r '.conclusion')
+          CREATED=$(echo "$RESULT" | jq -r '.createdAt')
+
+          echo "Last staging deploy: status=$STATUS conclusion=$CONCLUSION created=$CREATED"
+
+          if [ "$STATUS" != "completed" ]; then
+            echo "Staging deployment is still in progress ($STATUS). Wait for it to finish."
+            exit 1
+          fi
+
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "Last staging deployment failed ($CONCLUSION)."
+            echo "Fix the staging deployment before merging to main."
+            exit 1
+          fi
+
+          echo "Staging deployment passed."
+
+  # ---------------------------------------------------------------------------
   # PR Summary — aggregate results
   # ---------------------------------------------------------------------------
   pr-summary:
@@ -357,6 +406,7 @@ jobs:
       - secrets-detection
       - unit-tests
       - uv-lock-check
+      - staging-confidence
     if: always()
     steps:
       - name: Check job results
@@ -372,6 +422,7 @@ jobs:
           echo "| Secrets Detection | ${{ needs.secrets-detection.result }} |"
           echo "| Unit Tests | ${{ needs.unit-tests.result }} |"
           echo "| uv Lock Check | ${{ needs.uv-lock-check.result }} |"
+          echo "| Staging Confidence | ${{ needs.staging-confidence.result }} |"
           echo ""
 
           if [[ "${{ needs.issue-link-check.result }}" == "failure" ]] || \
@@ -379,7 +430,8 @@ jobs:
              [[ "${{ needs.code-quality.result }}" == "failure" ]] || \
              [[ "${{ needs.secrets-detection.result }}" == "failure" ]] || \
              [[ "${{ needs.unit-tests.result }}" == "failure" ]] || \
-             [[ "${{ needs.uv-lock-check.result }}" == "failure" ]]; then
+             [[ "${{ needs.uv-lock-check.result }}" == "failure" ]] || \
+             [[ "${{ needs.staging-confidence.result }}" == "failure" ]]; then
             echo "Required jobs failed — blocking merge."
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ See `dev/guidelines/git-workflow.md` for full details.
 1. **NEVER SSH or SCP directly to the GCP VM.** All changes must flow through Git.
 2. **ALWAYS create a feature branch** from `develop` (never commit directly to `main` or `develop`).
 3. **ALWAYS open a Pull Request** targeting `develop`. CI must pass before merge.
-4. **Deployment is automated.** Merging to `main` triggers the CD pipeline (`deploy.yml`) which SSHs to the VM, pulls code, and restarts the worker via systemd.
+4. **Deployment is automated.** Pushes to `develop` auto-deploy to **staging**; pushes to `main` deploy to **production** (requires reviewer approval). The staging pipeline also runs live integration tests (`pytest -m live`). See [ADR-0004](dev/adr/0004-branch-per-environment-deployment.md).
 5. **Infrastructure changes** (firewall rules, VM provisioning) must be documented in `docs/install.md` or an ADR, even if applied manually via `gcloud`.
 
 ### Workflow for Code Changes

--- a/changelog/73.added.md
+++ b/changelog/73.added.md
@@ -1,0 +1,1 @@
+Added live-tests job, release-confidence gate, and pytest `live` marker for staging VM pipeline

--- a/dev/guidelines/git-workflow.md
+++ b/dev/guidelines/git-workflow.md
@@ -125,25 +125,32 @@ The workflow commits directly to `main`. Two things are needed:
 
 ## Deployment (GitOps)
 
-Deployment is **fully automated** via GitHub Actions.
+Deployment is **fully automated** via GitHub Actions (see [ADR-0004](../dev/adr/0004-branch-per-environment-deployment.md)).
 
-| Trigger                    | Target               | Workflow                       |
-| -------------------------- | -------------------- | ------------------------------ |
-| PR merge to `main`         | GCP VM (staging)     | `.github/workflows/deploy.yml` |
-| Manual `workflow_dispatch` | dev / staging / prod | `.github/workflows/deploy.yml` |
+| Trigger                    | Target                      | Workflow                       |
+| -------------------------- | --------------------------- | ------------------------------ |
+| Push to `develop`          | Staging VM (auto-deploy)    | `.github/workflows/deploy.yml` |
+| Push to `main`             | Production VM (approval required) | `.github/workflows/deploy.yml` |
+| Manual `workflow_dispatch` | dev / staging / prod        | `.github/workflows/deploy.yml` |
 
 ### Pipeline stages
 
 1. **Validate** — `uv run invoke check-all` + unit tests
 2. **Deploy** — SSH to VM → `git pull` → `uv sync` → `systemctl restart synapse-worker`
 3. **Health check** — verify worker process, Temporal, Infrahub
+4. **Live tests** (staging only) — `pytest -m live` on the staging VM
 
-### Required GitHub Secrets
+### Production approval gate
+
+The `prod` GitHub Actions environment has **required reviewers** configured. Pushes to `main` pause at the environment protection rule until a reviewer approves. PRs targeting `main` also include a **staging-confidence** gate that verifies the last staging deployment succeeded.
+
+### Required GitHub Secrets (per environment)
 
 | Secret       | Purpose                               |
 | ------------ | ------------------------------------- |
 | `VM_SSH_KEY` | SSH private key for the deployment VM |
 | `VM_HOST`    | IP address of the GCP VM              |
+| `VM_USER`    | SSH username on the VM                |
 
 ## Issue Lifecycle
 

--- a/dev/guidelines/git-workflow.md
+++ b/dev/guidelines/git-workflow.md
@@ -125,7 +125,7 @@ The workflow commits directly to `main`. Two things are needed:
 
 ## Deployment (GitOps)
 
-Deployment is **fully automated** via GitHub Actions (see [ADR-0004](../dev/adr/0004-branch-per-environment-deployment.md)).
+Deployment is **fully automated** via GitHub Actions (see [ADR-0004](../adr/0004-branch-per-environment-deployment.md)).
 
 | Trigger                    | Target                      | Workflow                       |
 | -------------------------- | --------------------------- | ------------------------------ |

--- a/dev/knowledge/cicd-architecture.md
+++ b/dev/knowledge/cicd-architecture.md
@@ -657,10 +657,14 @@ This ensures the pr-summary job runs even when upstream jobs are skipped (path f
 Same jobs as PR validation plus:
 - **integration-tests** -- `pytest tests/integration/ --timeout=300` (depends on unit-tests, `continue-on-error: true`)
 
-### 9.5 Deploy (Manual Dispatch)
+### 9.5 Deploy (Auto + Manual)
+
+Triggered automatically on push to `develop` (→ staging) or `main` (→ prod), and manually via `workflow_dispatch`. See [ADR-0004](../adr/0004-branch-per-environment-deployment.md).
 
 ```yaml
 on:
+  push:
+    branches: [develop, main]
   workflow_dispatch:
     inputs:
       environment:
@@ -668,7 +672,20 @@ on:
         options: [dev, staging, prod]
 ```
 
-Uses GitHub Environments (`environment: ${{ github.event.inputs.environment }}`) for environment-specific secrets and protection rules.
+| Branch    | Environment | Deploy branch   | Approval |
+|-----------|-------------|-----------------|----------|
+| `develop` | staging     | `origin/develop`| auto     |
+| `main`    | prod        | `origin/main`   | required |
+
+Uses GitHub Environments for environment-specific secrets and protection rules. The `prod` environment has required reviewers configured as a deployment gate.
+
+**Jobs:** validate → deploy → health-check → live-tests (staging only)
+
+The **live-tests** job runs `pytest -m live` on the staging VM after health checks pass, executing tests that require Infrahub, Containerlab, and gNMI connectivity. JUnit XML results are uploaded as workflow artifacts.
+
+### 9.5a Release Confidence Gate (PR Validation)
+
+PRs targeting `main` include a **staging-confidence** job in `pr-validation.yml` that verifies the most recent Deploy workflow run on `develop` succeeded. This prevents merging to production when the staging deployment is broken.
 
 ### 9.6 Build Artifacts (Version Tags)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,8 @@ testpaths = ["tests"]
 markers = [
     "unit: Unit tests (no external dependencies)",
     "integration: Integration tests (requires Infrahub/Temporal/Containerlab)",
+    "live: Live infrastructure tests (requires running Infrahub/Containerlab/gNMI)",
+    "e2e: End-to-end pipeline tests",
     "slow: Slow tests (>30 seconds)",
     "pre_deployment: Pre-deployment validation",
     "post_deployment: Post-deployment validation",

--- a/tests/integration/test_placeholder.py
+++ b/tests/integration/test_placeholder.py
@@ -1,8 +1,14 @@
 """Integration tests — verify Infrahub connectivity and Containerlab device state.
 
-These tests require live infrastructure (Infrahub + Containerlab) to be running.
-They are gated by the ``@pytest.mark.integration`` marker and are skipped during
-normal ``pytest`` runs.  Use ``pytest -m integration`` to execute them.
+Tests are split into two marker categories:
+
+- ``@pytest.mark.integration`` — offline tests (config hygiene checks) that run
+  in CI without live infrastructure.
+- ``@pytest.mark.live`` — tests requiring running Infrahub, Containerlab, or gNMI.
+  These run only on the staging VM after deployment via ``deploy.yml``.
+
+Use ``pytest -m integration`` for offline tests, ``pytest -m live`` for
+live-infra tests.
 """
 
 from __future__ import annotations
@@ -18,6 +24,7 @@ import pytest
 
 
 @pytest.mark.integration
+@pytest.mark.live
 def test_infrahub_connection():
     """Verify that we can reach the Infrahub API and authenticate."""
     from network_synapse.infrahub.client import InfrahubConfigClient
@@ -35,6 +42,7 @@ def test_infrahub_connection():
 
 
 @pytest.mark.integration
+@pytest.mark.live
 def test_infrahub_device_config_retrieval():
     """Verify that we can retrieve a full device config from Infrahub."""
     from network_synapse.infrahub.client import InfrahubConfigClient
@@ -63,6 +71,7 @@ def test_infrahub_device_config_retrieval():
 
 
 @pytest.mark.integration
+@pytest.mark.live
 def test_containerlab_gnmi_connectivity():
     """Verify gNMI connectivity to a Containerlab SR Linux node."""
     from network_synapse.scripts.deploy_configs import validate_gnmi_connection
@@ -72,6 +81,7 @@ def test_containerlab_gnmi_connectivity():
 
 
 @pytest.mark.integration
+@pytest.mark.live
 def test_containerlab_bgp_state():
     """Verify BGP sessions are established on a Containerlab device."""
     from network_synapse.scripts.validate_state import check_bgp_summary

--- a/tests/integration/test_placeholder.py
+++ b/tests/integration/test_placeholder.py
@@ -23,7 +23,6 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
 @pytest.mark.live
 def test_infrahub_connection():
     """Verify that we can reach the Infrahub API and authenticate."""
@@ -41,7 +40,6 @@ def test_infrahub_connection():
         client.close()
 
 
-@pytest.mark.integration
 @pytest.mark.live
 def test_infrahub_device_config_retrieval():
     """Verify that we can retrieve a full device config from Infrahub."""
@@ -70,7 +68,6 @@ def test_infrahub_device_config_retrieval():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
 @pytest.mark.live
 def test_containerlab_gnmi_connectivity():
     """Verify gNMI connectivity to a Containerlab SR Linux node."""
@@ -80,7 +77,6 @@ def test_containerlab_gnmi_connectivity():
     assert validate_gnmi_connection(device_ip)
 
 
-@pytest.mark.integration
 @pytest.mark.live
 def test_containerlab_bgp_state():
     """Verify BGP sessions are established on a Containerlab device."""


### PR DESCRIPTION
## Summary

- Added pytest `live` marker to split integration tests: offline hygiene tests (`@pytest.mark.integration`) vs live-infra tests (`@pytest.mark.live`)
- Added `live-tests` job to `deploy.yml` — runs `pytest -m live` on the staging VM after health checks pass (staging only)
- Added `staging-confidence` gate to `pr-validation.yml` — blocks PRs targeting `main` unless the last staging deployment succeeded
- Updated documentation: CI/CD architecture, git workflow guide, and AGENTS.md with staging pipeline details

## Manual follow-up

Configure `prod` GitHub Actions environment with **required reviewers** at:
Settings → Environments → prod → Required reviewers

## Test plan

- [ ] Verify `pytest -m live` selects only the 4 live-infra tests (marker registration works with `--strict-markers`)
- [ ] Verify `pytest -m "integration and not live"` selects only the 2 offline hygiene tests
- [ ] Verify `staging-confidence` job is skipped for PRs targeting `develop` (this PR)
- [ ] Verify YAML lint passes on both workflow files
- [ ] After merge: trigger a staging deploy and confirm live-tests job runs

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live infrastructure tests run automatically after successful staging deployments.
  * PRs targeting main now include a staging-confidence gate requiring a successful staging deploy before merge.
  * Staging now auto-deploys on pushes; production deploys require approval.

* **Tests**
  * Added "live" and "e2e" test markers; several integration tests reclassified to run as live infra tests.

* **Documentation**
  * Updated deployment, workflow, and CI/CD guidance to reflect these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->