### PR TITLE
chore: rename GitHub username from chinga-chinga to anton-tvrz

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,27 +2,27 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owner for everything
-* @chinga-chinga
+* @anton-tvrz
 
 # Backend package
-/backend/ @chinga-chinga
+/backend/ @anton-tvrz
 
 # Workers package
-/workers/ @chinga-chinga
+/workers/ @anton-tvrz
 
 # Infrastructure
-/development/ @chinga-chinga
-/containerlab/ @chinga-chinga
-docker-compose*.yml @chinga-chinga
+/development/ @anton-tvrz
+/containerlab/ @anton-tvrz
+docker-compose*.yml @anton-tvrz
 
 # CI/CD
-/.github/ @chinga-chinga
+/.github/ @anton-tvrz
 
 # Documentation
-/docs/ @chinga-chinga
-/dev/ @chinga-chinga
+/docs/ @anton-tvrz
+/dev/ @anton-tvrz
 
 # Root configs — changes here affect the whole project
-pyproject.toml @chinga-chinga
-uv.lock @chinga-chinga
-.pre-commit-config.yaml @chinga-chinga
+pyproject.toml @anton-tvrz
+uv.lock @anton-tvrz
+.pre-commit-config.yaml @anton-tvrz

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: Feature Request
 description: Suggest a new feature or enhancement
 title: "[Feature]: "
 labels: ["enhancement"]
-assignees: ["chinga-chinga"]
+assignees: ["anton-tvrz"]
 body:
   - type: input
     id: branch_name

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -2,7 +2,7 @@ name: Task
 description: A development task or chore
 title: "[Task]: "
 labels: ["task"]
-assignees: ["chinga-chinga"]
+assignees: ["anton-tvrz"]
 body:
   - type: input
     id: branch_name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing! This guide will help you get starte
 
 ```bash
 # Clone the repository
-git clone https://github.com/chinga-chinga/project-network-synapse-3.git
+git clone https://github.com/anton-tvrz/project-network-synapse-3.git
 cd project-network-synapse-3
 
 # Initialize submodules

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Network automation platform for managing Nokia SR Linux datacenter fabric switch
 # Prerequisites: Python 3.11+, uv (https://docs.astral.sh/uv/)
 
 # Clone and setup
-git clone https://github.com/chinga-chinga/project-network-synapse-3.git
+git clone https://github.com/anton-tvrz/project-network-synapse-3.git
 cd project-network-synapse-3
 git submodule update --init --recursive
 uv sync --all-groups

--- a/changelog/83.changed.md
+++ b/changelog/83.changed.md
@@ -1,0 +1,1 @@
+Renamed GitHub account references from `chinga-chinga` to `anton-tvrz` and fixed runbook URL.

--- a/dev/adr/0002-monorepo-restructuring-plan.md
+++ b/dev/adr/0002-monorepo-restructuring-plan.md
@@ -224,10 +224,10 @@ Infrahub-style sections: Why, What changed, How to review, How to test, Impact &
 ### 6.3 `CODEOWNERS`
 
 ```
-/backend/    @chinga-chinga
-/workers/    @chinga-chinga
-/docs/       @chinga-chinga
-/development/ @chinga-chinga
+/backend/    @anton-tvrz
+/workers/    @anton-tvrz
+/docs/       @anton-tvrz
+/development/ @anton-tvrz
 ```
 
 ### 6.4 `dependabot.yml`

--- a/dev/guidelines/issue-management.md
+++ b/dev/guidelines/issue-management.md
@@ -103,7 +103,7 @@ This prevents accidental or premature manual closures.
 
 > **AI agents MUST follow these rules when working on issues.**
 
-1. **Never start work without an assignee** — add yourself or `chinga-chinga` if no human is assigned.
+1. **Never start work without an assignee** — add yourself or `anton-tvrz` if no human is assigned.
 2. **Always create a branch** matching the `## Branch` field in the issue body.
 3. **Check off sub-tasks** in the issue body as each one is completed.
 4. **Always open a PR with `Closes #N`** to link work back to the issue.

--- a/development/prometheus/alertmanager.yml
+++ b/development/prometheus/alertmanager.yml
@@ -47,7 +47,7 @@ receivers:
           - {{ .Annotations.summary }}
             {{ .Annotations.description }}
           {{ end }}
-          *Runbook:* https://github.com/chinga-chinga/project-network-synapse-3/blob/main/docs/runbooks/
+          *Runbook:* https://github.com/anton-tvrz/project-network-synapse-3/blob/main/docs/runbooks/
         send_resolved: true
 
   - name: "slack-warning"

--- a/development/prometheus/alertmanager.yml
+++ b/development/prometheus/alertmanager.yml
@@ -47,7 +47,7 @@ receivers:
           - {{ .Annotations.summary }}
             {{ .Annotations.description }}
           {{ end }}
-          *Runbook:* https://github.com/anton-tvrz/project-network-synapse-3/blob/main/docs/runbooks/
+          *Runbook:* https://github.com/anton-tvrz/project-network-synapse-3/blob/main/docs/runbooks.md
         send_resolved: true
 
   - name: "slack-warning"

--- a/development/synapse-worker.service
+++ b/development/synapse-worker.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Network Synapse Temporal Worker
-Documentation=https://github.com/chinga-chinga/project-network-synapse-3
+Documentation=https://github.com/anton-tvrz/project-network-synapse-3
 After=network.target docker.service
 Wants=docker.service
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -286,7 +286,7 @@ uv python list | grep 3.11  # Expect: Python 3.11 listed
 ```bash
 # Clone (adjust URL if using SSH)
 cd ~
-git clone https://github.com/chinga-chinga/project-network-synapse-3.git
+git clone https://github.com/anton-tvrz/project-network-synapse-3.git
 cd project-network-synapse-3
 ```
 

--- a/docs/manual-gcp-setup.md
+++ b/docs/manual-gcp-setup.md
@@ -34,7 +34,7 @@ Add to GitHub:
 Clone using SSH:
 
 ```bash
-git clone git@github.com:chinga-chinga/project-network-synapse-3.git
+git clone git@github.com:anton-tvrz/project-network-synapse-3.git
 ```
 
 ## UV

--- a/docs/running-the-worker.md
+++ b/docs/running-the-worker.md
@@ -26,7 +26,7 @@ export PATH=$HOME/.local/bin:$PATH
 
 # Clone the repo (skip if already cloned)
 cd ~
-git clone https://github.com/chinga-chinga/project-network-synapse-3.git
+git clone https://github.com/anton-tvrz/project-network-synapse-3.git
 cd project-network-synapse-3
 git submodule update --init --recursive
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,7 @@ package = "network_synapse"
 directory = "changelog"
 filename = "CHANGELOG.md"
 title_format = "## [{version}] - {project_date}"
-issue_format = "[#{issue}](https://github.com/chinga-chinga/project-network-synapse-3/issues/{issue})"
+issue_format = "[#{issue}](https://github.com/anton-tvrz/project-network-synapse-3/issues/{issue})"
 
 [[tool.towncrier.type]]
 directory = "added"


### PR DESCRIPTION
## Why
Closes #83

GitHub account renamed from `chinga-chinga` to `anton-tvrz`. All codebase references need updating before GitHub stops redirecting the old username.

## What changed
- Updated all 13 files referencing the old username (CODEOWNERS, issue templates, docs, configs)
- Fixed pre-existing bug: runbook URL pointed to non-existent `docs/runbooks/` directory → `docs/runbooks.md`

## How to Review
Straightforward find-and-replace. Verify no `chinga-chinga` references remain:
```bash
grep -r "chinga-chinga" .
```

## How to Test
- `git remote -v` → should show `anton-tvrz`
- `gh auth status` → should show `anton-tvrz`
- All CI checks pass

## Impact & Rollout
- [x] No code logic changes
- [x] No breaking changes
- [x] Safe to merge immediately

## Checklist
- [x] All references updated
- [x] Runbook URL bug fixed
- [x] Changelog fragment added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository URLs across setup and installation guides.
  
* **Chores**
  * Updated code ownership assignments and default issue template assignees.
  * Updated repository references in configuration files and alert runbooks.
  * Enhanced issue management guidelines with new closure and scope-change protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->