### PR TITLE
feat: add containerlab topology templates

### DIFF
--- a/changelog/99.added.md
+++ b/changelog/99.added.md
@@ -1,0 +1,1 @@
+Add containerlab topology templates (small, medium, large, border-leaf) for different lab testing scenarios.

--- a/containerlab/topologies/border-leaf.clab.yml
+++ b/containerlab/topologies/border-leaf.clab.yml
@@ -1,0 +1,75 @@
+# Border-leaf topology — DC gateway with WAN connectivity
+# Nodes: 2x dcgw (ixr-d3), 2x spine (ixr-d3), 2x leaf (ixr-d2), 2x server + 1x wan-router (linux)
+# Resources: ~4 vCPU / ~14 GB RAM
+# Use case: External connectivity, border routing, DCI testing
+# Deploy: sudo containerlab deploy --topo containerlab/topologies/border-leaf.clab.yml
+name: border-leaf-lab
+
+mgmt:
+  network: clab-border
+  ipv4-subnet: 172.20.33.0/24
+
+topology:
+  kinds:
+    nokia_srlinux:
+      image: ghcr.io/nokia/srlinux:24.10.1
+    linux:
+      image: ghcr.io/srl-labs/network-multitool
+
+  nodes:
+    # DC Gateways
+    dcgw01:
+      kind: nokia_srlinux
+      type: ixr-d3
+      mgmt-ipv4: 172.20.33.2
+    dcgw02:
+      kind: nokia_srlinux
+      type: ixr-d3
+      mgmt-ipv4: 172.20.33.3
+    # Spines
+    spine01:
+      kind: nokia_srlinux
+      type: ixr-d3
+      mgmt-ipv4: 172.20.33.10
+    spine02:
+      kind: nokia_srlinux
+      type: ixr-d3
+      mgmt-ipv4: 172.20.33.11
+    # Leaves
+    leaf01:
+      kind: nokia_srlinux
+      type: ixr-d2
+      mgmt-ipv4: 172.20.33.20
+    leaf02:
+      kind: nokia_srlinux
+      type: ixr-d2
+      mgmt-ipv4: 172.20.33.21
+    # Servers
+    srv01:
+      kind: linux
+      mgmt-ipv4: 172.20.33.30
+    srv02:
+      kind: linux
+      mgmt-ipv4: 172.20.33.31
+    # WAN Router
+    wan-router:
+      kind: linux
+      mgmt-ipv4: 172.20.33.32
+
+  links:
+    # DC-GW <-> Spine (full mesh)
+    - endpoints: ["dcgw01:e1-1", "spine01:e1-49"]
+    - endpoints: ["dcgw01:e1-2", "spine02:e1-49"]
+    - endpoints: ["dcgw02:e1-1", "spine01:e1-50"]
+    - endpoints: ["dcgw02:e1-2", "spine02:e1-50"]
+    # Spine <-> Leaf (full mesh)
+    - endpoints: ["spine01:e1-1", "leaf01:e1-49"]
+    - endpoints: ["spine01:e1-2", "leaf02:e1-49"]
+    - endpoints: ["spine02:e1-1", "leaf01:e1-50"]
+    - endpoints: ["spine02:e1-2", "leaf02:e1-50"]
+    # Leaf <-> Server
+    - endpoints: ["leaf01:e1-1", "srv01:eth1"]
+    - endpoints: ["leaf02:e1-1", "srv02:eth1"]
+    # DC-GW <-> WAN Router
+    - endpoints: ["dcgw01:e1-49", "wan-router:eth1"]
+    - endpoints: ["dcgw02:e1-49", "wan-router:eth2"]

--- a/containerlab/topologies/large.clab.yml
+++ b/containerlab/topologies/large.clab.yml
@@ -1,0 +1,72 @@
+# Large topology — Full Clos fabric
+# Nodes: 2x spine (ixr-d3), 4x leaf (ixr-d2), 4x server (linux)
+# Resources: ~4 vCPU / ~12 GB RAM
+# Use case: Production-like testing, ECMP, redundancy, failure scenario testing
+# Deploy: sudo containerlab deploy --topo containerlab/topologies/large.clab.yml
+name: large-lab
+
+mgmt:
+  network: clab-large
+  ipv4-subnet: 172.20.32.0/24
+
+topology:
+  kinds:
+    nokia_srlinux:
+      image: ghcr.io/nokia/srlinux:24.10.1
+    linux:
+      image: ghcr.io/srl-labs/network-multitool
+
+  nodes:
+    spine01:
+      kind: nokia_srlinux
+      type: ixr-d3
+      mgmt-ipv4: 172.20.32.10
+    spine02:
+      kind: nokia_srlinux
+      type: ixr-d3
+      mgmt-ipv4: 172.20.32.11
+    leaf01:
+      kind: nokia_srlinux
+      type: ixr-d2
+      mgmt-ipv4: 172.20.32.20
+    leaf02:
+      kind: nokia_srlinux
+      type: ixr-d2
+      mgmt-ipv4: 172.20.32.21
+    leaf03:
+      kind: nokia_srlinux
+      type: ixr-d2
+      mgmt-ipv4: 172.20.32.22
+    leaf04:
+      kind: nokia_srlinux
+      type: ixr-d2
+      mgmt-ipv4: 172.20.32.23
+    srv01:
+      kind: linux
+      mgmt-ipv4: 172.20.32.30
+    srv02:
+      kind: linux
+      mgmt-ipv4: 172.20.32.31
+    srv03:
+      kind: linux
+      mgmt-ipv4: 172.20.32.32
+    srv04:
+      kind: linux
+      mgmt-ipv4: 172.20.32.33
+
+  links:
+    # Fabric: spine01 <-> all leaves (e1-49 on leaf side)
+    - endpoints: ["spine01:e1-1", "leaf01:e1-49"]
+    - endpoints: ["spine01:e1-2", "leaf02:e1-49"]
+    - endpoints: ["spine01:e1-3", "leaf03:e1-49"]
+    - endpoints: ["spine01:e1-4", "leaf04:e1-49"]
+    # Fabric: spine02 <-> all leaves (e1-50 on leaf side)
+    - endpoints: ["spine02:e1-1", "leaf01:e1-50"]
+    - endpoints: ["spine02:e1-2", "leaf02:e1-50"]
+    - endpoints: ["spine02:e1-3", "leaf03:e1-50"]
+    - endpoints: ["spine02:e1-4", "leaf04:e1-50"]
+    # Server: leaf <-> host (one server per leaf)
+    - endpoints: ["leaf01:e1-1", "srv01:eth1"]
+    - endpoints: ["leaf02:e1-1", "srv02:eth1"]
+    - endpoints: ["leaf03:e1-1", "srv03:eth1"]
+    - endpoints: ["leaf04:e1-1", "srv04:eth1"]

--- a/containerlab/topologies/medium.clab.yml
+++ b/containerlab/topologies/medium.clab.yml
@@ -1,0 +1,47 @@
+# Medium topology — Enhanced spine-leaf with hosts
+# Nodes: 1x spine (ixr-d3), 2x leaf (ixr-d2), 2x server (linux)
+# Resources: ~2 vCPU / ~6 GB RAM
+# Use case: Multi-path testing, basic service validation, end-to-end traffic between hosts
+# Deploy: sudo containerlab deploy --topo containerlab/topologies/medium.clab.yml
+name: medium-lab
+
+mgmt:
+  network: clab-medium
+  ipv4-subnet: 172.20.31.0/24
+
+topology:
+  kinds:
+    nokia_srlinux:
+      image: ghcr.io/nokia/srlinux:24.10.1
+    linux:
+      image: ghcr.io/srl-labs/network-multitool
+
+  nodes:
+    spine01:
+      kind: nokia_srlinux
+      type: ixr-d3
+      mgmt-ipv4: 172.20.31.10
+    leaf01:
+      kind: nokia_srlinux
+      type: ixr-d2
+      mgmt-ipv4: 172.20.31.20
+    leaf02:
+      kind: nokia_srlinux
+      type: ixr-d2
+      mgmt-ipv4: 172.20.31.21
+    srv01:
+      kind: linux
+      mgmt-ipv4: 172.20.31.30
+    srv02:
+      kind: linux
+      mgmt-ipv4: 172.20.31.31
+
+  links:
+    # Fabric: spine <-> leaf (dual uplinks per leaf)
+    - endpoints: ["spine01:e1-1", "leaf01:e1-49"]
+    - endpoints: ["spine01:e1-2", "leaf02:e1-49"]
+    - endpoints: ["spine01:e1-3", "leaf01:e1-50"]
+    - endpoints: ["spine01:e1-4", "leaf02:e1-50"]
+    # Server: leaf <-> host
+    - endpoints: ["leaf01:e1-1", "srv01:eth1"]
+    - endpoints: ["leaf02:e1-1", "srv02:eth1"]

--- a/containerlab/topologies/small.clab.yml
+++ b/containerlab/topologies/small.clab.yml
@@ -1,0 +1,29 @@
+# Small topology — Single leaf-spine pair
+# Nodes: 1x spine (ixr-d3), 1x leaf (ixr-d2)
+# Resources: ~2 vCPU / ~3 GB RAM
+# Use case: Minimal protocol testing, quick iteration, single BGP session validation
+# Deploy: sudo containerlab deploy --topo containerlab/topologies/small.clab.yml
+name: small-lab
+
+mgmt:
+  network: clab-small
+  ipv4-subnet: 172.20.30.0/24
+
+topology:
+  kinds:
+    nokia_srlinux:
+      image: ghcr.io/nokia/srlinux:24.10.1
+
+  nodes:
+    spine01:
+      kind: nokia_srlinux
+      type: ixr-d3
+      mgmt-ipv4: 172.20.30.10
+    leaf01:
+      kind: nokia_srlinux
+      type: ixr-d2
+      mgmt-ipv4: 172.20.30.20
+
+  links:
+    - endpoints: ["spine01:e1-1", "leaf01:e1-49"]
+    - endpoints: ["spine01:e1-2", "leaf01:e1-50"]


### PR DESCRIPTION
## Summary
- Add 4 containerlab topology templates under `containerlab/topologies/` for different lab testing scenarios
- **small** — 1 spine + 1 leaf, minimal protocol testing (~3 GB RAM)
- **medium** — 1 spine + 2 leaf + 2 servers, multi-path/e2e traffic (~6 GB RAM)
- **large** — 2 spine + 4 leaf + 4 servers, full Clos fabric (~12 GB RAM)
- **border-leaf** — 2 dcgw + 2 spine + 2 leaf + 2 srv + 1 wan-router, DC gateway/DCI testing (~14 GB RAM)
- All topologies use pinned SR Linux 24.10.1, static management IPs on unique /24 subnets, and consistent interface naming conventions

## Test plan
- [ ] `uv run yamllint containerlab/topologies/` passes with no errors
- [ ] Each file is valid containerlab YAML with correct `name`, `mgmt`, `topology` structure
- [ ] Management IPs are static and non-overlapping across topologies (172.20.30-33.0/24)
- [ ] Interface naming follows project conventions (leaf uplinks e1-49/e1-50, spine downlinks e1-1+)
- [ ] Deploy smoke test: `sudo containerlab deploy --topo containerlab/topologies/small.clab.yml`

## Related
- Closes anton-tvrz/project-network-synapse-3#99
- Parent epic: anton-tvrz/project-network-synapse-quattro#10
- Follow-up seed data issue: anton-tvrz/project-network-synapse-3#106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four containerlab topology configurations: small, medium, large, and border-leaf variants. These enable deployment of spine-leaf and border-gateway network architectures with varying scales, from minimal testing setups to full Clos fabrics with multiple server nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->